### PR TITLE
Add assertion in TaskList.java

### DIFF
--- a/src/main/java/hal/task/TaskList.java
+++ b/src/main/java/hal/task/TaskList.java
@@ -21,6 +21,8 @@ public class TaskList {
         String returnOutput;
 
         try {
+            assert(userInput.length() > 1);
+
             ArrayList<String> parsedInputArray = parser.parse(userInput);
             String taskType = parsedInputArray.get(0);
             String description = parsedInputArray.get(1);
@@ -42,7 +44,7 @@ public class TaskList {
             Task taskObject = taskList.get(taskList.size() - 1);
             returnOutput = taskObject.toString();
 
-        } catch (HALException | DateTimeParseException e) {
+        } catch (HALException | DateTimeParseException | AssertionError e) {
             System.out.println(e.getMessage());
             returnOutput = "Give me clearer instructions. I cannot do that.";
         }


### PR DESCRIPTION
Previously, error checking only ensures dates were in correct format

Meant that errors pertaining to tasks without descriptions were not caught

Lets catch errors where there is no task description